### PR TITLE
Migrate ApplicationDbContext to .NET 8 and EntityFrameworkCore

### DIFF
--- a/new_app/HotelReservationSystem/Data/ApplicationDbContext.cs
+++ b/new_app/HotelReservationSystem/Data/ApplicationDbContext.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using HotelReservationSystem.Models;
+
+namespace HotelReservationSystem.Data;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+{
+    public DbSet<Customer> Customers { get; set; } = null!;
+    public DbSet<Hotel> Hotels { get; set; } = null!;
+    public DbSet<Country> Countries { get; set; } = null!;
+    public DbSet<Order> Orders { get; set; } = null!;
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+    
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+        
+        // Configure relationships and constraints here
+        // Configure Order -> Customer relationship
+        builder.Entity<Order>()
+            .HasOne(o => o.Customer)
+            .WithMany()
+            .HasForeignKey(o => o.CustomerId)
+            .OnDelete(DeleteBehavior.Cascade);
+            
+        // Configure Order -> Hotel relationship
+        builder.Entity<Order>()
+            .HasOne(o => o.Hotel)
+            .WithMany()
+            .HasForeignKey(o => o.HotelId)
+            .OnDelete(DeleteBehavior.Cascade);
+            
+        // Configure Hotel -> Country relationship
+        builder.Entity<Hotel>()
+            .HasOne(h => h.Country)
+            .WithMany()
+            .HasForeignKey(h => h.CountryId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}


### PR DESCRIPTION
This PR migrates the ApplicationDbContext from the legacy .NET Framework 4.5.2 application to .NET 8.

## Changes
- Created a separate Data folder for the context following modern .NET conventions
- Updated the ApplicationDbContext to use Microsoft.EntityFrameworkCore instead of System.Data.Entity
- Added constructor that accepts DbContextOptions for dependency injection
- Configured entity relationships explicitly in OnModelCreating
- Added proper null handling with nullable reference types
- Added OnDelete behaviors for relationships

## Migration Notes
- The new context uses dependency injection pattern instead of the static Create() method
- Entity relationships are now configured using Fluent API in OnModelCreating
- Added explicit foreign key properties that were missing in the original Order entity

## Testing
This context will be used with the migrated entities and requires the following NuGet packages:
- Microsoft.EntityFrameworkCore
- Microsoft.EntityFrameworkCore.SqlServer
- Microsoft.AspNetCore.Identity.EntityFrameworkCore