### PR TITLE
Migrate HomeController to .NET 8 standards

### DIFF
--- a/new_app/Controllers/HomeController.cs
+++ b/new_app/Controllers/HomeController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics;
+using HotelReservationSystem.Models;
+
+namespace HotelReservationSystem.Controllers
+{
+    public class HomeController : Controller
+    {
+        private readonly ILogger<HomeController> _logger;
+
+        public HomeController(ILogger<HomeController> logger)
+        {
+            _logger = logger;
+        }
+
+        public IActionResult Index()
+        {
+            return View();
+        }
+
+        public IActionResult About()
+        {
+            ViewBag.Message = "Your application description page.";
+            return View();
+        }
+
+        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+        public IActionResult Error()
+        {
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+    }
+}

--- a/new_app/Models/ErrorViewModel.cs
+++ b/new_app/Models/ErrorViewModel.cs
@@ -1,0 +1,9 @@
+namespace HotelReservationSystem.Models
+{
+    public class ErrorViewModel
+    {
+        public string? RequestId { get; set; }
+
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+    }
+}


### PR DESCRIPTION
This PR migrates the HomeController to .NET 8 standards by:

1. Adding ILogger through dependency injection
2. Replacing ActionResult with IActionResult
3. Adding Error action method with ResponseCache attribute
4. Removing OutputCache attribute (using Response Caching middleware instead)

Added ErrorViewModel class to support the Error action method.