### PR TITLE
Add DTOs with nullable reference type support

### DIFF
--- a/new_app/DTOs/CountryDto.cs
+++ b/new_app/DTOs/CountryDto.cs
@@ -1,0 +1,8 @@
+namespace HotelReservationSystem.DTOs;
+
+public class CountryDto
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}

--- a/new_app/DTOs/HotelDto.cs
+++ b/new_app/DTOs/HotelDto.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace HotelReservationSystem.DTOs;
+
+public class HotelDto
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(255)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public int CountryId { get; set; }
+
+    public CountryDto? Country { get; set; }
+
+    [Required]
+    [MaxLength(50)]
+    public string City { get; set; } = string.Empty;
+
+    [Required]
+    [Range(1, 5)]
+    public int Stars { get; set; }
+
+    [Required]
+    [Range(1, 1000)]
+    public double PricePerNight { get; set; }
+
+    [Required]
+    public bool IsAllInclusive { get; set; }
+}


### PR DESCRIPTION
This pull request adds the following DTOs for the .NET 8 version of the application:

1. HotelDto.cs - Updated with nullable reference type support and modern C# syntax
2. CountryDto.cs - Updated with nullable reference type support and modern C# syntax

The DTOs follow .NET 8 best practices:
- Using file-scoped namespaces
- Providing default values for non-nullable reference types
- Using the nullable annotation syntax for optional references
- Following modern C# coding style

These DTOs maintain the same functionality as the original ones but with improved type safety.